### PR TITLE
Update auth.server.ts

### DIFF
--- a/complete-application/app/services/auth.server.ts
+++ b/complete-application/app/services/auth.server.ts
@@ -1,4 +1,4 @@
-import jwt_decode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 import { Authenticator } from "remix-auth";
 import { sessionStorage } from "~/services/session.server";
 import { OAuth2Strategy, OAuth2StrategyOptions } from "remix-auth-oauth2";
@@ -19,7 +19,7 @@ const authStrategy = new OAuth2Strategy(
     authOptions,
     async ({accessToken, refreshToken, extraParams, profile, context, request}) => {
         type Token = { email: string }
-        const token: Token = jwt_decode(accessToken);
+        const token: Token = jwtDecode(accessToken);
         return token.email;
     }
 );

--- a/complete-application/package-lock.json
+++ b/complete-application/package-lock.json
@@ -11,7 +11,7 @@
         "@remix-run/serve": "^1.19.3",
         "dotenv": "^16.3.1",
         "isbot": "^3.6.8",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "remix-auth": "^3.5.1",
@@ -7943,9 +7943,12 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.3",

--- a/complete-application/package.json
+++ b/complete-application/package.json
@@ -14,7 +14,7 @@
     "@remix-run/serve": "^1.19.3",
     "dotenv": "^16.3.1",
     "isbot": "^3.6.8",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remix-auth": "^3.5.1",


### PR DESCRIPTION
The package https://www.npmjs.com/package/jwt-decode changed to the named export `jwtDecode` and not the default export `jwt_decode`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206283383737693